### PR TITLE
feat: support multiple attributions in license

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,28 @@ async function verifySourceFiles() {
     core.info('No attribution detected in LICENSE.');
     core.info(`We will use ${attribution}`);
   } else {
-    core.info(`Detected attribution ${attribution}`);
+    const split = attribution.split('\\n');
+    if (split.length > 1) {
+      // We have multiple attributions, which can occur with a forked
+      // repository. We may be obligated to retain the original attribution,
+      // e.g., with the MIT license. We'll select the attribution that contains
+      // COMPANY_NAME.
+      core.info('Multiple attributions have been detected:');
+      for (let i in split) {
+        let att = split[i];
+        core.info(`${att}`);
+      }
+      attribution = split.find(function(att) {
+        return att.includes(COMPANY_NAME);
+      });
+      if (attribution === undefined) {
+        core.setFailed(`None of the attributions contained our company name ${COMPANY_NAME}`);
+        return;
+      }
+      core.info(`We will use ${attribution}`);
+    } else {
+      core.info(`Detected attribution ${attribution}`);
+    }
   }
 
   core.info(`Searching source files for copyright notice '${attribution}'`);


### PR DESCRIPTION
In a forked repository, it's possible for there to be multiple attributions in the LICENSE file: the
original copyright holder and our own new attribution. Some licenses, e.g., MIT, require the
original to be preserved in the fork.

Multiple attributions will be returned from `jq.run` as a single string, with each attribution
delineated by a newline character, so we can use a split to determine if multiple are present. If
so, we will use the one that contains the company name specified in by our `company-name` workflow
input.